### PR TITLE
Use graceful-fs 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   ],
   "dependencies": {
     "gulp-util": "~2.2.0",
-    "graceful-fs": "~2.0.0",
+    "graceful-fs": "~4.1.0",
     "filesize": "~2.0.0",
     "temp-write": "~0.1.0",
     "map-stream": "0.0.4",


### PR DESCRIPTION
Fixes warning

    warning gulp-jsmin > graceful-fs@2.0.3: graceful-fs v3.0.0 and before will fail on node releases >= v7.0. Please update to graceful-fs@^4.0.0 as soon as possible. Use 'npm ls graceful-fs' to find it in the tree.

Tests passed